### PR TITLE
`project_spec` forbids ssh git urls in `.gitmodules`.

### DIFF
--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -79,3 +79,7 @@ end
 describe file 'spec/spec_helper.rb' do
   it { should exist }
 end
+
+describe file '.gitmodules' do
+  its(:content) { should_not include 'git@github.com' }
+end


### PR DESCRIPTION
closes #6
