### PR TITLE
Extract `recipes/common.rb`.

### DIFF
--- a/recipes/common.rb
+++ b/recipes/common.rb
@@ -1,0 +1,38 @@
+include_recipe 'apt'
+
+project_user = node['infrastructure']['project_user']
+project_root = node['infrastructure']['project_root']
+
+# Install git from PPA
+apt_repository 'git-ppa' do
+  uri 'http://ppa.launchpad.net/git-core/ppa/ubuntu'
+  distribution node['lsb']['codename']
+  components %w(main)
+  key 'E1DF1F24'
+  keyserver 'keyserver.ubuntu.com'
+end
+
+package 'bash-completion'
+package 'curl'
+package 'dstat'
+package 'git'
+package 'iftop'
+package 'iotop'
+package 'iperf'
+package 'jq'
+package 'lsof'
+package 'man-db'
+package 'mlocate'
+package 'nano'
+package 'strace'
+package 'sysstat'
+package 'unzip'
+package 'wget'
+package 'zip'
+
+# Install our gem dependencies if any
+execute 'bundle-install' do
+  command "bundle install --gemfile=#{project_root}/Gemfile"
+  user project_user
+  only_if { File.exist? "#{project_root}/Gemfile" }
+end

--- a/recipes/vagrant.rb
+++ b/recipes/vagrant.rb
@@ -1,35 +1,6 @@
-include_recipe 'apt'
-
 project_name = node['infrastructure']['project_name']
 project_user = node['infrastructure']['project_user']
 project_root = node['infrastructure']['project_root']
-
-# Install git from PPA
-apt_repository 'git-ppa' do
-  uri 'http://ppa.launchpad.net/git-core/ppa/ubuntu'
-  distribution node['lsb']['codename']
-  components %w(main)
-  key 'E1DF1F24'
-  keyserver 'keyserver.ubuntu.com'
-end
-
-package 'bash-completion'
-package 'curl'
-package 'dstat'
-package 'git'
-package 'iftop'
-package 'iotop'
-package 'iperf'
-package 'jq'
-package 'lsof'
-package 'man-db'
-package 'mlocate'
-package 'nano'
-package 'strace'
-package 'sysstat'
-package 'unzip'
-package 'wget'
-package 'zip'
 
 # The canonical Vagrantfile
 template "#{project_root}/Vagrantfile" do
@@ -162,12 +133,7 @@ template '/etc/profile.d/chefdk.sh' do
   source 'etc/profile.d/chefdk.sh.erb'
 end
 
-# Install our gem dependencies if any
-execute 'bundle-install' do
-  command "bundle install --gemfile=#{project_root}/Gemfile"
-  user project_user
-  only_if { File.exist? "#{project_root}/Gemfile" }
-end
+include_recipe 'infrastructure::common'
 
 # Run the serverspec suite enforcing that client-controlled files are up to date
 execute 'rspec-project-spec' do

--- a/spec/common_spec.rb
+++ b/spec/common_spec.rb
@@ -1,0 +1,65 @@
+require 'spec_helper'
+
+describe 'infrastructure::common' do
+  let(:hostname) { 'the-hostname' }
+  let(:project_root) { 'the-project-root' }
+
+  let(:chef_run) do
+    ChefSpec::SoloRunner.new do |node|
+      node.automatic['hostname'] = hostname
+      node.set['infrastructure']['project_root'] = project_root
+    end.converge(described_recipe)
+  end
+
+  it 'includes apt' do
+    expect(chef_run).to include_recipe('apt')
+  end
+
+  it 'adds the git apt repository' do
+    code_name = chef_run.node['lsb']['codename']
+    expect(chef_run).to add_apt_repository('git-ppa').with(
+      uri: 'http://ppa.launchpad.net/git-core/ppa/ubuntu',
+      distribution: code_name,
+      components: %w(main),
+      key: 'E1DF1F24',
+      keyserver: 'keyserver.ubuntu.com')
+  end
+
+  %w(
+    bash-completion
+    curl
+    dstat
+    git
+    iftop
+    iotop
+    iperf
+    jq
+    lsof
+    man-db
+    mlocate
+    nano
+    strace
+    sysstat
+    unzip
+    wget
+    zip
+  ).each do |package|
+    it "installs #{package}" do
+      expect(chef_run).to install_package(package)
+    end
+  end
+
+  it 'installs bundler dependencies if Gemfile exists' do
+    allow(File).to receive(:exist?).and_call_original
+    allow(File).to receive(:exist?).with("#{project_root}/Gemfile").and_return(true)
+    expect(chef_run).to run_execute('bundle-install').with(
+      command: "bundle install --gemfile=#{project_root}/Gemfile",
+      user: 'vagrant')
+  end
+
+  it 'does not install bundler dependencies if Gemfile is absent' do
+    allow(File).to receive(:exist?).and_call_original
+    allow(File).to receive(:exist?).with("#{project_root}/Gemfile").and_return(false)
+    expect(chef_run).to_not run_execute('bundle-install')
+  end
+end

--- a/spec/vagrant_spec.rb
+++ b/spec/vagrant_spec.rb
@@ -11,44 +11,6 @@ describe 'infrastructure::vagrant' do
     end.converge(described_recipe)
   end
 
-  it 'includes apt' do
-    expect(chef_run).to include_recipe('apt')
-  end
-
-  it 'adds the git apt repository' do
-    code_name = chef_run.node['lsb']['codename']
-    expect(chef_run).to add_apt_repository('git-ppa').with(
-      uri: 'http://ppa.launchpad.net/git-core/ppa/ubuntu',
-      distribution: code_name,
-      components: %w(main),
-      key: 'E1DF1F24',
-      keyserver: 'keyserver.ubuntu.com')
-  end
-
-  %w(
-    bash-completion
-    curl
-    dstat
-    git
-    iftop
-    iotop
-    iperf
-    jq
-    lsof
-    man-db
-    mlocate
-    nano
-    strace
-    sysstat
-    unzip
-    wget
-    zip
-  ).each do |package|
-    it "installs #{package}" do
-      expect(chef_run).to install_package(package)
-    end
-  end
-
   it 'creates ./Vagrantfile' do
     expect(chef_run).to create_template("#{project_root}/Vagrantfile").with(
       source: 'vagrant/Vagrantfile.erb',
@@ -283,18 +245,8 @@ describe 'infrastructure::vagrant' do
       source: 'etc/profile.d/chefdk.sh.erb')
   end
 
-  it 'installs bundler dependencies if Gemfile exists' do
-    allow(File).to receive(:exist?).and_call_original
-    allow(File).to receive(:exist?).with("#{project_root}/Gemfile").and_return(true)
-    expect(chef_run).to run_execute('bundle-install').with(
-      command: "bundle install --gemfile=#{project_root}/Gemfile",
-      user: 'vagrant')
-  end
-
-  it 'does not install bundler dependencies if Gemfile is absent' do
-    allow(File).to receive(:exist?).and_call_original
-    allow(File).to receive(:exist?).with("#{project_root}/Gemfile").and_return(false)
-    expect(chef_run).to_not run_execute('bundle-install')
+  it 'includes common' do
+    expect(chef_run).to include_recipe('infrastructure::common')
   end
 
   it 'runs the project spec' do


### PR DESCRIPTION
Project generation from the template is left in `recipes/vagrant`, but installed packages and `bundle install` move to common.

closes #11
