### PR TITLE
Bring in vim and tmux, flush out gitignore.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,6 +6,7 @@ end_of_line = lf
 indent_size = 2
 indent_style = space
 insert_final_newline = true
+max_line_length = 90
 trim_trailing_whitespace = true
 
 [Makefile]

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,37 @@
 # From infrastructure
-.vagrant
 bin
+
+# Vagrant
+.vagrant/
+
+# Vim
+*~
+.netrwhist
+Session.vim
+[._]*.s[a-w][a-z]
+[._]s[a-w][a-z]
+tags
+
+# Emacs
+*.elc
+*.rel
+*_archive
+*_flymake.*
+*~
+.\#*
+.cask/
+.dir-locals.el
+.org-id-locations
+.projectile
+/.emacs.desktop
+/.emacs.desktop.lock
+/auto/
+/elpa/
+/eshell/history
+/eshell/lastdir
+/server/
+\#*\#
+auto-save-list
+dist/
+flycheck_*.el
+tramp

--- a/provisioning/client-vagrant
+++ b/provisioning/client-vagrant
@@ -26,6 +26,7 @@ fi
 sudo apt-get install -y software-properties-common
 
 sudo add-apt-repository -y ppa:git-core
+sudo add-apt-repository -y ppa:jonathonf/vim
 sudo apt-get update
 
 . "$(dirname ${BASH_SOURCE[0]})/client-common"
@@ -46,7 +47,9 @@ sudo apt-get install -y \
   nano \
   strace \
   sysstat \
+  tmux \
   unzip \
+  vim \
   wget \
   zip
 

--- a/templates/.gitignore
+++ b/templates/.gitignore
@@ -1,3 +1,37 @@
 # From infrastructure
-.vagrant
 bin
+
+# Vagrant
+.vagrant/
+
+# Vim
+*~
+.netrwhist
+Session.vim
+[._]*.s[a-w][a-z]
+[._]s[a-w][a-z]
+tags
+
+# Emacs
+*.elc
+*.rel
+*_archive
+*_flymake.*
+*~
+.\#*
+.cask/
+.dir-locals.el
+.org-id-locations
+.projectile
+/.emacs.desktop
+/.emacs.desktop.lock
+/auto/
+/elpa/
+/eshell/history
+/eshell/lastdir
+/server/
+\#*\#
+auto-save-list
+dist/
+flycheck_*.el
+tramp

--- a/vagrant/common
+++ b/vagrant/common
@@ -33,6 +33,19 @@ Vagrant.configure('2') do |config|
     config.vm.provision :file, source: '~/.gitconfig', destination: '.gitconfig'
   end
 
+  if File.exist? "#{ENV['HOME']}/.vimrc"
+    config.vm.provision :file, source: '~/.vimrc', destination: '.vimrc'
+  end
+
+  if Dir.exist? "#{ENV['HOME']}/.vim"
+    config.vm.provision :shell, privileged: false, inline: 'rm -rf ~/.vim'
+    config.vm.provision :file, source: '~/.vim', destination: '.vim'
+  end
+
+  if File.exist? "#{ENV['HOME']}/.tmux.conf"
+    config.vm.provision :file, source: '~/.tmux.conf', destination: '.tmux.conf'
+  end
+
   config.vm.provision :shell do |shell|
     shell.privileged = false
     shell.keep_color = true


### PR DESCRIPTION
In addition to installing vim guest-side, any host-side `~/.vimrc` and `~/.vim/` are
copied down into the guest. `~/.tmux.conf` is similarly downloaded.

Support files for vim and emacs are ignored.  The list is taken from [0].  In
`.editorconfig` the `max_line_length` has also been explicitly set to `90`.

closes #31 

[0]: https://github.com/github/gitignore