### PR TITLE
Use the stock vim 7 instead of PPA vim 8.

### DIFF
--- a/provisioning/client-vagrant
+++ b/provisioning/client-vagrant
@@ -28,7 +28,6 @@ sudo apt-get install -y software-properties-common
 
 sudo add-apt-repository -y ppa:brightbox/ruby-ng
 sudo add-apt-repository -y ppa:git-core
-sudo add-apt-repository -y ppa:jonathonf/vim
 sudo apt-get update
 
 . "$(dirname ${BASH_SOURCE[0]})/client-common"


### PR DESCRIPTION
I have no particular need for 8, but the PPA version lacks python support.  I do need that
for the coq plugins.