### PR TITLE
Changes required to support the book repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Build intermediates
+build
+
 # Vagrant
 .vagrant/
 

--- a/Makefile
+++ b/Makefile
@@ -11,15 +11,29 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 
+.DEFAULT: all
+
 SHELL := /bin/bash
 
+ALL :=
+TEST :=
+
+include */build.mk
+
 .PHONY: all
-all:
+all: $(ALL)
 
 .PHONY: test
-test: all
+test: $(TEST)
 
 .PHONY: continuous-integration
 continuous-integration: test
 
-include */build.mk
+.PHONY: clean
+clean:
+	-rm -r build
+
+build:
+	mkdir -p build
+
+$(ALL): | build

--- a/infrastructure/bin/check-boilerplate
+++ b/infrastructure/bin/check-boilerplate
@@ -60,9 +60,9 @@ export -f has_vim_modeline
   -name .editorconfig -prune -o  \
   -name .travis.yml -prune -o \
   -name .vagrant -prune -o  \
+  -name CC-BY-SA-4.0 -prune -o \
   -name GPL-3 -prune -o \
   -name LICENSE -prune -o \
-  -name vendor -prune -o  \
   -name version -prune -o \
   $(test -f .check-boilerplate && cat .check-boilerplate) \
   -exec git check-ignore -q '{}' \; -prune -o \

--- a/infrastructure/build.mk
+++ b/infrastructure/build.mk
@@ -11,7 +11,7 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 
-test: infrastructure-test
+TEST += infrastructure-test
 
 .PHONY: infrastructure-test
 infrastructure-test:

--- a/infrastructure/provisioning/common
+++ b/infrastructure/provisioning/common
@@ -22,7 +22,10 @@ cd "$PROJECT_DIR"
 
 sudo apt-get install -y \
   curl \
-  jq
+  jq \
+  texlive \
+  texlive-latex-extra \
+  texlive-math-extra
 
 curl -sL -o /tmp/bats-v0.4.0.tar.gz \
   'https://github.com/sstephenson/bats/archive/v0.4.0.tar.gz'


### PR DESCRIPTION
* Being the first occasion to need ./build, integrate it into the build.  Specifically use
  an "order only" constraint (the |) to mkdir if necessary without triggering
  recompilation of build artifacts merely when directory metadata changes.

  Additionally, since glob expansion in targets (apparently) consider only files and not
  declared-but-absent targets, pivot away from declaring dependencies against e.g. all
  directly and instead collect them in variables such as ALL.  Then we may declare a mass
  dependency on build without explicit enumeration.
* Bring in the few packages and boilerplate ignores that the book repo needs