### PR TITLE
Development environment docker image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,9 @@
-sudo: true
-dist: trusty
+sudo: required
+services:
+  - docker
 language: c
-install: bash infrastructure/provisioning/travis
-script: bash -l -c 'make continuous-integration'
-deploy:
-  provider: releases
-  api_key:
-    # travis encrypt $API_KEY --add deploy.api_key
-    secure: FCppLoNwAEMxxk71KAKGcFd1/e3XSBTFL4zdpnQkWv0+JW5EDoIPkECbeaTbK2p1HYFVqKTPzPF27gVK2iVYHppt8FctWSudMyM2QEBBiPPgBWsItsVqG7BzwDrL8PFZK0bka9+t4oJ8dquMIw7G6Vj38a05R784g4vqjf+tt6rXSCtZ0HyquGUnIxgJtzMieAJ6g2uYZT3mf+uFBnCLemoTddzjmWB/06zn0smGPr1n4mPXYIMa9aKcnPUz1hpNl1pHGsp30qSX0nIhtYMbhkdMKginkUfqYXMIdrHyNkxV9nYvcNqtAtEXzMAfF5EW7H9UcKhD49+VrQGThV44tytybNN8Ts5ntjgrU1mxgSgRXMcTLNrDJ4DRvaEyLW0BxQO4E3LUSYZ+wLcCdJi5rVGb/yPexp5mQHuSRelGqNfwMXwInjEPeE+DUyl+vXgeSYizKJIL9e1uxY7PqfQoaDYzIIdx6sWyMQ37VHrgER2+ioteJHtx/qcr8dXhIPgFcFkumJJxS+9qo/7RhWNWNTLnjV2WuPT5MQ/v3LfbOWbMgQuNrQJz2snVRGCGjX3xSHoDTfSDiZ01c7BWbPiLjShTNaol6XdmuTRRRANx309vgtkzULp/Eolc3pidIY/fMHUyjXW0Qf9xZAGgmMPrnel2MgnrpB56XnB0Clg1nys=
-  file: build/way-the-definitive-guide.pdf
-  skip_cleanup: true
-  on:
-    tags: true
+script:
+  - date
+  - export PATH="$PATH:$TRAVIS_BUILD_DIR/infrastructure/bin"
+  - docker-run-development bash -c 'date; make continuous-integration'
+  - date

--- a/book/build.mk
+++ b/book/build.mk
@@ -11,7 +11,7 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 
-ALL += build/way-the-definitive-guide.pdf
+ALL += $(BUILD)/way-the-definitive-guide.pdf
 
 build/way-the-definitive-guide.pdf:
 	# Twice to build the table of contents, http://stackoverflow.com/q/3863630/580412

--- a/infrastructure/bin/docker-run-development
+++ b/infrastructure/bin/docker-run-development
@@ -1,4 +1,6 @@
-# vim: filetype=make
+#! /bin/bash
+# vim: filetype=sh
+
 # Copyright (C) 2016-2018 Philip H. Smith
 
 # This program is free software: you can redistribute it and/or modify
@@ -11,31 +13,12 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 
-SHELL := /bin/bash
+set -e -u -o pipefail
 
-BUILD ?= build
-ALL :=
-TEST :=
-CLEAN :=
+ROOT="$(cd $(dirname "${BASH_SOURCE[0]}")/../..; pwd)"
+VERSION=$(provisioning-version)
 
-.PHONY: all
-all:
+pull-or-build-docker-development-image
 
-include */build.mk
-
-all: $(ALL)
-
-.PHONY: test
-test: $(TEST)
-
-.PHONY: continuous-integration
-continuous-integration: test
-
-.PHONY: clean
-clean: $(CLEAN)
-	-rm -r $(BUILD)
-
-$(BUILD):
-	mkdir -p $(BUILD)
-
-$(ALL): | $(BUILD)
+docker run -it --rm --name way -v "$ROOT:/way" "waylang/development:$VERSION" \
+  bash -l -c 'cd /way && export BUILD=~/build && "$@"' -- "$@"

--- a/infrastructure/bin/provisioning-version
+++ b/infrastructure/bin/provisioning-version
@@ -1,4 +1,6 @@
-# vim: filetype=make
+#! /bin/bash
+# vim: filetype=sh
+
 # Copyright (C) 2016-2018 Philip H. Smith
 
 # This program is free software: you can redistribute it and/or modify
@@ -11,31 +13,8 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 
-SHELL := /bin/bash
-
-BUILD ?= build
-ALL :=
-TEST :=
-CLEAN :=
-
-.PHONY: all
-all:
-
-include */build.mk
-
-all: $(ALL)
-
-.PHONY: test
-test: $(TEST)
-
-.PHONY: continuous-integration
-continuous-integration: test
-
-.PHONY: clean
-clean: $(CLEAN)
-	-rm -r $(BUILD)
-
-$(BUILD):
-	mkdir -p $(BUILD)
-
-$(ALL): | $(BUILD)
+find infrastructure/provisioning -type f \
+  | LC_ALL=C sort \
+  | xargs sha256sum \
+  | sha256sum \
+  | cut -c 1-12

--- a/infrastructure/bin/pull-or-build-docker-development-image
+++ b/infrastructure/bin/pull-or-build-docker-development-image
@@ -1,4 +1,6 @@
-# vim: filetype=make
+#! /bin/bash
+# vim: filetype=sh
+
 # Copyright (C) 2016-2018 Philip H. Smith
 
 # This program is free software: you can redistribute it and/or modify
@@ -11,31 +13,15 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 
-SHELL := /bin/bash
+set -e -u -o pipefail
 
-BUILD ?= build
-ALL :=
-TEST :=
-CLEAN :=
+ROOT="$(cd $(dirname "${BASH_SOURCE[0]}")/../..; pwd)"
+PROVISIONING_VERSION=$(provisioning-version)
 
-.PHONY: all
-all:
-
-include */build.mk
-
-all: $(ALL)
-
-.PHONY: test
-test: $(TEST)
-
-.PHONY: continuous-integration
-continuous-integration: test
-
-.PHONY: clean
-clean: $(CLEAN)
-	-rm -r $(BUILD)
-
-$(BUILD):
-	mkdir -p $(BUILD)
-
-$(ALL): | $(BUILD)
+if ! docker pull "waylang/development:$PROVISIONING_VERSION"
+then
+  docker build \
+    -t "waylang/development:$PROVISIONING_VERSION" \
+    -t waylang/development:latest \
+    "$ROOT/infrastructure/provisioning"
+fi

--- a/infrastructure/provisioning/.dockerignore
+++ b/infrastructure/provisioning/.dockerignore
@@ -1,4 +1,5 @@
-# vim: filetype=make
+# vim: filetype=dockerignore
+
 # Copyright (C) 2016-2018 Philip H. Smith
 
 # This program is free software: you can redistribute it and/or modify
@@ -11,31 +12,6 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 
-SHELL := /bin/bash
-
-BUILD ?= build
-ALL :=
-TEST :=
-CLEAN :=
-
-.PHONY: all
-all:
-
-include */build.mk
-
-all: $(ALL)
-
-.PHONY: test
-test: $(TEST)
-
-.PHONY: continuous-integration
-continuous-integration: test
-
-.PHONY: clean
-clean: $(CLEAN)
-	-rm -r $(BUILD)
-
-$(BUILD):
-	mkdir -p $(BUILD)
-
-$(ALL): | $(BUILD)
+*
+!common
+!docker

--- a/infrastructure/provisioning/Dockerfile
+++ b/infrastructure/provisioning/Dockerfile
@@ -1,5 +1,4 @@
-#! /bin/bash
-# vim: filetype=sh
+# vim: filetype=dockerfile
 
 # Copyright (C) 2016-2018 Philip H. Smith
 
@@ -13,7 +12,9 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 
-set -e -u -o pipefail
-set -x
-
-. "$TRAVIS_BUILD_DIR/infrastructure/provisioning/common"
+FROM ubuntu:16.04
+COPY common docker /
+RUN chmod +x /docker && \
+    /docker && \
+    rm /common /docker
+USER way

--- a/infrastructure/provisioning/common
+++ b/infrastructure/provisioning/common
@@ -20,13 +20,28 @@ export PROJECT_DIR="${PROJECT_DIR:-$(pwd)}"
 
 cd "$PROJECT_DIR"
 
-sudo apt-get install -y \
+sudo apt-get update -y
+sudo apt-get upgrade -y
+
+sudo apt-get install -y --no-install-recommends \
+  apt-transport-https \
+  ca-certificates \
+  software-properties-common
+
+sudo add-apt-repository -y ppa:git-core
+sudo apt-get update -y
+
+sudo apt-get install -y --no-install-recommends \
   coq \
   curl \
+  git \
   jq \
-  texlive \
-  texlive-latex-extra \
-  texlive-math-extra
+  lmodern \
+  make \
+  texlive
+
+sudo apt-get clean
+sudo apt-get autoclean
 
 curl -sL -o /tmp/bats-v0.4.0.tar.gz \
   'https://github.com/sstephenson/bats/archive/v0.4.0.tar.gz'
@@ -36,6 +51,8 @@ sha256sum -c - <<'EOF'
 EOF
 
 sudo tar -C /opt -xzf /tmp/bats-v0.4.0.tar.gz
+
+rm /tmp/bats-v0.4.0.tar.gz
 
 sudo tee /etc/profile.d/way.sh <<EOF
 export PATH="\$PATH:$PROJECT_DIR/infrastructure/bin"

--- a/infrastructure/provisioning/docker
+++ b/infrastructure/provisioning/docker
@@ -1,4 +1,6 @@
-# vim: filetype=make
+#! /bin/bash
+# vim: filetype=sh
+
 # Copyright (C) 2016-2018 Philip H. Smith
 
 # This program is free software: you can redistribute it and/or modify
@@ -11,31 +13,23 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 
-SHELL := /bin/bash
+set -e -u -o pipefail
+set -x
 
-BUILD ?= build
-ALL :=
-TEST :=
-CLEAN :=
+apt-get update -y
+apt-get upgrade -y
+apt-get install -y --no-install-recommends sudo
 
-.PHONY: all
-all:
+useradd way -m -G sudo
+USER=way
 
-include */build.mk
+cat >> /etc/sudoers.d/way <<'EOF'
+way ALL=(ALL) NOPASSWD:ALL
+EOF
 
-all: $(ALL)
+touch ~way/.sudo_as_admin_successful
 
-.PHONY: test
-test: $(TEST)
+export PROJECT_DIR=/way
+mkdir "$PROJECT_DIR"
 
-.PHONY: continuous-integration
-continuous-integration: test
-
-.PHONY: clean
-clean: $(CLEAN)
-	-rm -r $(BUILD)
-
-$(BUILD):
-	mkdir -p $(BUILD)
-
-$(ALL): | $(BUILD)
+. '/common'

--- a/infrastructure/provisioning/vagrant
+++ b/infrastructure/provisioning/vagrant
@@ -16,25 +16,25 @@
 set -e -u -o pipefail
 set -x
 
-sudo apt-get update
-sudo apt-get upgrade -y
-
-sudo apt-get install -y software-properties-common
-sudo add-apt-repository -y ppa:git-core
-sudo apt-get update
-
 . '/vagrant/infrastructure/provisioning/common'
 
-sudo apt-get install -y \
+# https://docs.docker.com/install/linux/docker-ce/ubuntu/#set-up-the-repository
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+sudo apt-key fingerprint 0EBFCD88 | fgrep -q 'Docker Release (CE deb)'
+sudo add-apt-repository \
+ "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+
+sudo apt-get update -y
+
+sudo apt-get install -y --no-install-recommends \
   bash-completion \
   build-essential \
+  docker-ce \
   dstat \
-  git \
   iftop \
   iotop \
   iperf \
   lsof \
-  make \
   man-db \
   mlocate \
   nano \
@@ -46,6 +46,8 @@ sudo apt-get install -y \
   vim-nox-py2 \
   wget \
   zip
+
+sudo usermod -aG docker "$USER"
 
 # Color prompts
 sed -i 's|#force_color|force_color|' "$HOME/.bashrc"

--- a/infrastructure/test.bats
+++ b/infrastructure/test.bats
@@ -29,6 +29,14 @@
   type release-to-github
 }
 
+@test 'make is executable' {
+  type make
+}
+
+@test 'sha256sum is executable' {
+  type sha256sum
+}
+
 @test 'version is a file' {
   test -f version
 }

--- a/metatheory/build.mk
+++ b/metatheory/build.mk
@@ -12,8 +12,8 @@
 # GNU General Public License for more details.
 
 COQ_SRCS := $(wildcard metatheory/Way/*.v)
-COQ_DEPS := $(patsubst metatheory/Way/%.v,build/Way/%.d,$(COQ_SRCS))
-COQ_OBJS := $(patsubst metatheory/Way/%.v,build/Way/%.vo,$(COQ_SRCS))
+COQ_DEPS := $(patsubst metatheory/Way/%.v,$(BUILD)/Way/%.d,$(COQ_SRCS))
+COQ_OBJS := $(patsubst metatheory/Way/%.v,$(BUILD)/Way/%.vo,$(COQ_SRCS))
 
 ALL += $(COQ_OBJS)
 
@@ -21,23 +21,23 @@ TEST += verify-metatheory
 
 .PHONY: verify-metatheory
 verify-metatheory: $(COQ_OBJS)
-	coqchk.opt -R build '' Way.Repl
+	coqchk.opt -R $(BUILD) '' Way.Repl
 
 .PHONY: coq-repl
 coq-repl: $(COQ_OBJS)
-	rlwrap -pGREEN coqtop.opt -R build '' -require Repl
+	rlwrap -pGREEN coqtop.opt -R $(BUILD) '' -require Repl
 
-build/Way: | build
-	mkdir -p build/Way
+$(BUILD)/Way: | $(BUILD)
+	mkdir -p $(BUILD)/Way
 
-build/Way/%.d: metatheory/Way/%.v | build/Way
-	coqdep -I metatheory/Way -as Way $< | sed 's|metatheory|build|g' > $@
+$(BUILD)/Way/%.d: metatheory/Way/%.v | $(BUILD)/Way
+	coqdep -I metatheory/Way -as Way $< | sed 's|metatheory|$(BUILD)|g' > $@
 
 include $(COQ_DEPS)
 
 # coqc is simply unable to build files in a separate directory, so copy over the source
-build/Way/%.v: metatheory/Way/%.v | build/Way
+$(BUILD)/Way/%.v: metatheory/Way/%.v | $(BUILD)/Way
 	cp $< $@
 
-build/Way/%.vo: build/Way/%.v
-	coqc -opt -noglob -I build/Way -as Way $<
+$(BUILD)/Way/%.vo: $(BUILD)/Way/%.v
+	coqc -opt -noglob -I $(BUILD)/Way -as Way $<


### PR DESCRIPTION
It is waylang/development, available [here][0].

Docker tooling is installed in provisioning/vagrant.

A few new scripts have been added to infrastructure/bin:
* provisioning-version hashes the content of infrastructure/provisioning to produce a id
  suitable for development images.
* pull-or-build-docker-development-image attempts to fetch the docker image at the version
  given by provisioning-version.  If it can't it builds it instead.
* docker-run-development runs an arbitrary command within the image, with the source tree
  mounted at /way.

Additionally:
* The clean target has been added to Makefile, which includes can hook into by appending
  to CLEAN.  Locally cached copies of waylang/development are removed this way.
* Travis builds now run the appropriate make target with docker-run-development.  Aside
  from possibly building the image, they no longer need a provisioning step.
* The build directory is now parameterized by the BUILD make variable.  The default is
  build.  This allows the docker image to not worry about ownership or permissions in the
  mounte source tree.

[0]: https://hub.docker.com/r/waylang/development/

Closes #48