### PR TITLE
Debian Stretch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@
 
 SHELL := /bin/bash
 
-BUILD ?= build
+BUILD ?= $(HOME)/build
 ALL :=
 TEST :=
 CLEAN :=

--- a/infrastructure/bin/docker-run-development
+++ b/infrastructure/bin/docker-run-development
@@ -20,5 +20,11 @@ VERSION=$(provisioning-version)
 
 pull-or-build-docker-development-image
 
-docker run -it --rm --name way -v "$ROOT:/way" "waylang/development:$VERSION" \
-  bash -l -c 'cd /way && export BUILD=~/build && "$@"' -- "$@"
+docker run \
+  --interactive \
+  --tty \
+  --rm \
+  --name way \
+  --volume "$ROOT:/way/src" \
+  "waylang/development:$VERSION" \
+  bash -l -c 'cd /way/src && "$@"' -- "$@"

--- a/infrastructure/provisioning/Dockerfile
+++ b/infrastructure/provisioning/Dockerfile
@@ -12,7 +12,7 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 
-FROM ubuntu:16.04
+FROM debian:stretch
 COPY common docker /
 RUN chmod +x /docker && \
     /docker && \

--- a/infrastructure/provisioning/common
+++ b/infrastructure/provisioning/common
@@ -16,9 +16,16 @@
 set -e -u -o pipefail
 set -x
 
-export PROJECT_DIR="${PROJECT_DIR:-$(pwd)}"
+# For coq 8.4
+sudo tee /etc/apt/sources.list.d/jessie.list <<'EOF'
+deb http://deb.debian.org/debian jessie main
+deb-src http://deb.debian.org/debian jessie main
+EOF
 
-cd "$PROJECT_DIR"
+sudo tee /etc/apt/sources.list.d/backports.list <<'EOF'
+deb http://ftp.debian.org/debian stretch-backports main
+deb-src http://ftp.debian.org/debian stretch-backports main
+EOF
 
 sudo apt-get update -y
 sudo apt-get upgrade -y
@@ -26,19 +33,28 @@ sudo apt-get upgrade -y
 sudo apt-get install -y --no-install-recommends \
   apt-transport-https \
   ca-certificates \
+  curl \
+  gnupg2 \
   software-properties-common
 
-sudo add-apt-repository -y ppa:git-core
 sudo apt-get update -y
 
 sudo apt-get install -y --no-install-recommends \
-  coq \
-  curl \
-  git \
   jq \
   lmodern \
   make \
   texlive
+
+sudo apt-get install -y --no-install-recommends \
+  -t stretch-backports \
+  git
+
+sudo apt-get install -y --no-install-recommends \
+  coq-theories=8.4pl4dfsg-1 \
+  coq=8.4pl4dfsg-1 \
+  libcoq-ocaml=8.4pl4dfsg-1 \
+  liblablgtk2-ocaml=2.16.0+dfsg-1 \
+  ocaml-base-nox=4.01.0-5
 
 sudo apt-get clean
 sudo apt-get autoclean
@@ -54,7 +70,8 @@ sudo tar -C /opt -xzf /tmp/bats-v0.4.0.tar.gz
 
 rm /tmp/bats-v0.4.0.tar.gz
 
-sudo tee /etc/profile.d/way.sh <<EOF
-export PATH="\$PATH:$PROJECT_DIR/infrastructure/bin"
-export PATH="\$PATH:/opt/bats-0.4.0/bin"
+sudo tee /etc/profile.d/way.sh <<'EOF'
+export PATH="$PATH:/sbin"
+export PATH="$PATH:/way/src/infrastructure/bin"
+export PATH="$PATH:/opt/bats-0.4.0/bin"
 EOF

--- a/infrastructure/provisioning/docker
+++ b/infrastructure/provisioning/docker
@@ -29,7 +29,4 @@ EOF
 
 touch ~way/.sudo_as_admin_successful
 
-export PROJECT_DIR=/way
-mkdir "$PROJECT_DIR"
-
 . '/common'

--- a/infrastructure/provisioning/vagrant
+++ b/infrastructure/provisioning/vagrant
@@ -16,13 +16,12 @@
 set -e -u -o pipefail
 set -x
 
-. '/vagrant/infrastructure/provisioning/common'
+. /way/src/infrastructure/provisioning/common
 
-# https://docs.docker.com/install/linux/docker-ce/ubuntu/#set-up-the-repository
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-sudo apt-key fingerprint 0EBFCD88 | fgrep -q 'Docker Release (CE deb)'
+curl -fsSL https://download.docker.com/linux/debian/gpg | sudo apt-key add -
+sudo apt-key fingerprint 0EBFCD88
 sudo add-apt-repository \
- "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+ "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable"
 
 sudo apt-get update -y
 
@@ -43,7 +42,7 @@ sudo apt-get install -y --no-install-recommends \
   sysstat \
   tmux \
   unzip \
-  vim-nox-py2 \
+  vim \
   wget \
   zip
 
@@ -56,4 +55,7 @@ sed -i 's|#force_color|force_color|' "$HOME/.bashrc"
 sudo timedatectl set-timezone UTC
 
 # Softlink to code
-sudo ln -sfT /vagrant "$HOME/way"
+sudo ln -sfT /way/src "$HOME/src"
+
+sudo apt-get autoremove
+sudo apt-get clean


### PR DESCRIPTION
Drop ubuntu for debian, ubuntu doesn't seem to have recent box images
and making them is proving complicated re: cloud init.

At the same time, simplify some other things:
* Put the source directory at /way/src, discarding /vagrant and
  PROJECT_DIR.  Incidentally this re-enabled vboxfs, as the base debian
  image uses rsync.
* Require vagrant-vbguest plugin
* Ditch a lot of the dotfiles customization, you're free to copy your
  own in manually.
* Explicitly install coq 8.4 from backports, as the metatheory is not
  yet compatible with the default 8.6.